### PR TITLE
[PR] Filter content syndicate output

### DIFF
--- a/articles/post.php
+++ b/articles/post.php
@@ -18,7 +18,7 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 		<?php endif; // is_single() or in_a_relationship() ?>
 		</hgroup>
 		<hgroup class="source">
-			 ( <time class="article-date" datetime="<?php echo get_the_date( 'c' ); ?>"><?php echo get_the_date(); ?></time> )
+			 <time class="article-date" datetime="<?php echo get_the_date( 'c' ); ?>"><?php echo get_the_date(); ?></time>
 		</hgroup>
 
 		<?php if ( is_singular() && in_array( $post_share_placement, array( 'top', 'both' ) ) ) : ?>

--- a/functions.php
+++ b/functions.php
@@ -13,3 +13,26 @@ add_filter( 'the_excerpt', 'ucomm_the_excerpt' );
 	}
 	return $excerpt;
 }
+
+add_filter( 'wsu_content_syndicate_host_data', 'innovators_filter_syndicate_host_data', 10, 2 );
+/**
+ * Filter the thumbnail used from a remote host with WSU Content Syndicate
+ *
+ * @param object $subset Data associated with a single remote item.
+ * @param object $post   Original data used to build the subset.
+ *
+ * @return object Modified data.
+ */
+function innovators_filter_syndicate_host_data( $subset, $post ) {
+	if ( isset( $post->featured_image ) && isset( $post->_embedded->{'https://api.w.org/featuredmedia'} ) && 0 < count( $post->_embedded->{'https://api.w.org/featuredmedia'} ) ) {
+		$subset_feature = $post->_embedded->{'https://api.w.org/featuredmedia'}[0]->media_details;
+		if ( isset( $subset_feature->sizes->{'spine-medium_size'} ) ) {
+			$subset->thumbnail = $subset_feature->sizes->{'spine-medium_size'}->source_url;
+		} else {
+			$subset->thumbnail = $post->_embedded->{'https://api.w.org/featuredmedia'}[0]->source_url;
+		}
+	} else {
+		$subset->thumbnail = false;
+	}
+	return $subset;
+}


### PR DESCRIPTION
- Use the featured image if available when outputting content syndicate excerpts.
- Remove the parentheses around the date output on posts.
